### PR TITLE
peerDeps を renovate の管理外に

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["github>hatena/renovate-config", "schedule:monthly"],
+  "extends": ["github>hatena/renovate-config", "schedule:monthly", ":disablePeerDependencies"],
   "ignorePresets": ["github>hatena/renovate-config:schedule"],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "ignorePresets": ["github>hatena/renovate-config:schedule"],
   "packageRules": [
     {
-      "depTypeList": ["devDependencies"],
+      "matchDepTypes": ["devDependencies"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
- 今の設定だと renovate により peerDeps もアップデートされるようになっている
  - ref: https://github.com/hatena/eslint-config-hatena/pull/6/commits/b7cf804a2e5290c45566b7faf59ccf074ef3ec31
- peerDeps をアップデートするとライブラリを利用可能なプロジェクトが意図せず減ってしまうので困る
- そのため peerDeps を renovate の管理外にしたい
