### PR TITLE
eslint のエラーに prettier のエラーを含めないように

### DIFF
--- a/+prettier.js
+++ b/+prettier.js
@@ -2,5 +2,5 @@
 
 /** @type import('eslint').Linter.BaseConfig */
 module.exports = {
-  extends: ['plugin:prettier/recommended', 'prettier'],
+  extends: ['prettier'],
 };

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm i -D @typescript-eslint/eslint-plugin @typescript-eslint/parser typescript
 npm i -D eslint-plugin-react eslint-plugin-react-hooks
 
 # `@hatena/hatena/+prettier` を利用する場合は以下も追加でインストール
-npm i -D eslint-config-prettier eslint-plugin-prettier prettier
+npm i -D eslint-config-prettier prettier
 ```
 
 ## 使い方

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -35,25 +35,14 @@ prettier と併用している場合は以下のように記述すると良い�
 
 ## prettier
 
-[`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) の `prettier/prettier` rule により、ESLint のエラー報告に prettier のエラーも含まれるようになります。そのため以下のように prettier のエラーを報告する npm-scripts を別途用意する必要はありません。
+eslint-config-hatena では prettier と競合する format に関する rule が off になっています。ESLint だけでは未フォーマットのコードを検知したり、format したりできないので、以下のように npm-scripts を別途用意しておくと良いでしょう。
 
 ```json
 {
   "scripts": {
     "check": "run-s check:*",
     "check:prettier": "prettier --check .",
-    "check:eslint": "eslint src test"
-    // ...
-  }
-}
-```
-
-次のように記述するだけで十分です。
-
-```json
-{
-  "scripts": {
-    "check": "run-s check:*",
+    "check:prettier:fix": "prettier --write .",
     "check:eslint": "eslint src test"
     // ...
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint": ">=6.8.0",
     "eslint-config-prettier": ">=8.0.0",
     "eslint-plugin-import": ">=2.20.2",
-    "eslint-plugin-prettier": ">=3.1.3",
     "eslint-plugin-react": ">=7.19.0",
     "eslint-plugin-react-hooks": ">=4.0.0",
     "prettier": ">=2.0.5",
@@ -76,7 +75,6 @@
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.24.2",
-    "eslint-plugin-prettier": "^4.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.3.2",
     "typescript": "^4.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,13 +389,6 @@ eslint-plugin-import@^2.24.2:
     resolve "^1.20.0"
     tsconfig-paths "^3.11.0"
 
-eslint-plugin-prettier@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"
-  integrity sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==
-  dependencies:
-    prettier-linter-helpers "^1.0.0"
-
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -514,11 +507,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
-
-fast-diff@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
-  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -1058,13 +1046,6 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
-
-prettier-linter-helpers@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
-  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
-  dependencies:
-    fast-diff "^1.1.2"
 
 prettier@^2.3.2:
   version "2.3.2"


### PR DESCRIPTION
- 様々な理由により eslint のエラーに prettier のエラーを含めるようにするのは推奨されていない
  - https://zenn.dev/teppeis/articles/2021-02-eslint-prettier-vscode#%E8%83%8C%E6%99%AF
- ので、やめてしまう