### PR TITLE
ES2020 の構文がパースできない問題を修正

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,12 +47,15 @@ module.exports = {
 
 ![required YES](https://img.shields.io/badge/requrired-YES-red) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/index.js)
 
-純粋な ECMAScript を lint するための rule をまとめた config です。[ESLint の `env`](https://eslint.org/docs/user-guide/configuring#specifying-environments) により、ソースコードが ES2020 に準拠しているものとして lint するよう構成されています。プロジェクトでターゲットとしている ECMAScript のバージョンが ES2020 より低い場合は、適時 `env` で設定を上書きして下さい。
+純粋な ECMAScript を lint するための rule をまとめた config です。[ESLint の `env`](https://eslint.org/docs/user-guide/configuring#specifying-environments) により、ソースコードが ES2020 に準拠しているものとして lint するよう構成されています。プロジェクトでターゲットとしている ECMAScript のバージョンが ES2020 より低い場合は、適時 `parserOptions.ecmaVersion` と `env` で設定を上書きして下さい。
 
 ```javascript
 module.exports = {
   root: true,
   extends: ['@hatena/hatena'],
+  parserOptions: {
+    ecmaVersion: 2019,
+  },
   env: {
     es2019: true,
     es2020: false,

--- a/index.js
+++ b/index.js
@@ -3,14 +3,6 @@
 /** @type import('eslint').Linter.BaseConfig */
 module.exports = {
   plugins: ['import'],
-  env: {
-    // アプリケーションによってサポートされている ECMAScript のバージョンは違うので、
-    // 本来であればアプリケーションで利用している Node.js のバージョンやサポートブラウザの
-    // バージョンに合わせて上書きするべきするべき設定だが、いちいち上書きするのも面倒なので、
-    // ひとまず一番最新のバージョンが利用可能であるとしておき、必要に応じてアプリケーションサイドで
-    // 上書きしてもらう、という運用にする
-    es2020: true,
-  },
   extends: [
     // eslint
     'eslint:recommended',
@@ -22,6 +14,17 @@ module.exports = {
     // 現代では type="script" な環境で JS を書くことはまずないので、
     // デフォルトで type="module" なJSであるとして lint する
     sourceType: 'module',
+    // ES2020 の構文がパースできるように。
+    // NOTE: アプリケーションによってサポートされている ECMAScript のバージョンは違うので、
+    // 本来であればアプリケーションで利用している Node.js のバージョンやサポートブラウザの
+    // バージョンに合わせて上書きするべきするべき設定だが、いちいち上書きするのも面倒なので、
+    // ひとまず一番最新のバージョンが利用可能であるとしておき、必要に応じてアプリケーションサイドで
+    // 上書きしてもらう、という運用にする
+    ecmaVersion: 2020,
+  },
+  env: {
+    // `parserOptions.ecmaVersion` に揃えておく
+    es2020: true,
   },
   rules: {
     // eslint


### PR DESCRIPTION
- `parserOptions.ecmaVersion` を指定し忘れていた
- `env` だけだと ES2020 で追加されたグローバルオブジェクトが読み込まれるが、新しい構文には対応できていなかった