### PR TITLE
Replace set-output for the GitHub Workflows to address the deprecation warnings

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: cache
@@ -51,7 +51,7 @@ jobs:
       # package.json からバージョンを取得する
       - name: package-version
         id: package-version
-        run: echo "::set-output name=version::$(cat package.json | jq -r .version)"
+        run: echo "version=$(cat package.json | jq -r .version)" >> $GITHUB_OUTPUT
 
       # まだ tag がないバージョンなら tag を push する
       - name: package-version-to-git-tag


### PR DESCRIPTION
This is to address the following issue:
[GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I executed the following command.
```
npx set-env-to-github_env
```