### PR TITLE
`@hatena/prettier-config-hatena` を URL 指定でインストールする

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@hatena:registry=https://npm.pkg.github.com/

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     }
   },
   "devDependencies": {
-    "@hatena/prettier-config-hatena": "^0.0.1",
+    "@hatena/prettier-config-hatena": "https://github.com/hatena/prettier-config-hatena.git#v1.0.0",
     "eslint": "^8.39.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,10 +34,9 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.39.0.tgz#58b536bcc843f4cd1e02a7e6171da5c040f4d44b"
   integrity sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==
 
-"@hatena/prettier-config-hatena@^0.0.1":
-  version "0.0.1"
-  resolved "https://npm.pkg.github.com/download/@hatena/prettier-config-hatena/0.0.1/87c157a5838c2b3746863d2c12934b65670295e0f9a5c9a297c2d046bf7f8f40#d7663d72b65778cca75d6760245cd09144e1cfe8"
-  integrity sha512-R4TYsMHKW2WCdctga+yzku3aaiRDYa6mULVoQ5lLjDwE/uJ/Duzf3Do7HSASGs7S1FzO6U4bU0VAV4bsnt/q+Q==
+"@hatena/prettier-config-hatena@https://github.com/hatena/prettier-config-hatena.git#v1.0.0":
+  version "1.0.0"
+  resolved "https://github.com/hatena/prettier-config-hatena.git#4cd05e0eebc08b91ad606a30d62798ea620ff82d"
 
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"


### PR DESCRIPTION
GitHub Packages 経由では、`yarn install` する際に GitHub PAT が必要で、開発の障壁が高くなってしまいます。

- ref: [GitHub Packages を npm install するための手段あれこれ - mizdra's blog](https://www.mizdra.net/entry/2021/03/31/235055)

一方で、`@hatena/prettier-config-hatena` は public リポジトリかつ事前ビルドが不要なパッケージであるため、 [GitHub Packages を npm install するための手段あれこれ - mizdra's blog](https://www.mizdra.net/entry/2021/03/31/235055) の案4のような方法でインストールすることができます。この方法であれば PAT がなくともインストールできるようです。

`npm outdated` や `npm update` の対象外となるデメリットがありますが、eslint-config-hatena では renovate を使って依存関係のアップデートをしており、 Renovate は URL 指定でインストールした npm package もアップデートしてくれるので、問題になることは無いだろうと思っています。
