### PR TITLE
設定を現代に合わせる & 扱いやすくするために更新

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,20 +47,19 @@ module.exports = {
 
 ### `@hatena/hatena`
 
-![required YES](https://img.shields.io/badge/required-YES-red) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/index.js)
+![required YES](https://img.shields.io/badge/required-YES-red) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/lib/classic/javascript.js)
 
-純粋な ECMAScript を lint するための rule をまとめた config です。[ESLint の `env`](https://eslint.org/docs/user-guide/configuring#specifying-environments) により、ソースコードが ES2020 に準拠しているものとして lint するよう構成されています。プロジェクトでターゲットとしている ECMAScript のバージョンが ES2020 より低い場合は、適時 `parserOptions.ecmaVersion` と `env` で設定を上書きして下さい。
+純粋な ECMAScript を lint するための rule をまとめた config です。
+
+[`env`](https://eslint.org/docs/user-guide/configuring#specifying-environments) は指定していませんので、プロジェクトでターゲットとしている ECMAScript のバージョンや環境に応じて、適宜 `env` を設定してください
 
 ```javascript
 module.exports = {
   root: true,
   extends: ['@hatena/hatena'],
-  parserOptions: {
-    ecmaVersion: 2019,
-  },
   env: {
-    es2019: true,
-    es2020: false,
+    es2024: true,
+    browser: true,
   },
   rules: {
     // プロジェクト固有のルールをここに書く
@@ -70,9 +69,9 @@ module.exports = {
 
 ### `@hatena/hatena/+typescript`
 
-![required no](https://img.shields.io/badge/required-no-inactive) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/+typescript.js)
+![required no](https://img.shields.io/badge/required-no-inactive) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/lib/classic/typescript.js)
 
-TypeScript を利用しているプロジェクト向けの config です。この config を利用するにはプロジェクトで使用している `tsconfig.json` を `parserOptions.project` に記述する必要があります (省略すると `./tsconfig.json` が使われます)。
+TypeScript を利用しているプロジェクト向けの config です。
 
 ```javascript
 module.exports = {
@@ -88,7 +87,9 @@ module.exports = {
     {
       files: ['*.ts', '*.tsx'],
       parserOptions: {
-        project: './frontend/tsconfig.json',
+        // tsconfig.json を指定する必要がある場合はここに追加してください
+        // デフォルトでは対象ファイルに最も近い tsconfig.json が使用されます
+        // project: './frontend/tsconfig.json',
         // tsconfig.json が複数ある場合は配列で次のように指定して下さい
         // project: [
         //   './frontend/tsconfig.json',
@@ -106,13 +107,13 @@ module.exports = {
 
 ### `@hatena/hatena/+react`
 
-![required no](https://img.shields.io/badge/required-no-inactive) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/+react.js)
+![required no](https://img.shields.io/badge/required-no-inactive) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/lib/classic/react.js)
 
 React を利用しているプロジェクト向けの config です。
 
 ### `@hatena/hatena/+prettier`
 
-![required no](https://img.shields.io/badge/required-no-inactive) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/+prettier.js)
+![required no](https://img.shields.io/badge/required-no-inactive) [![see source](https://img.shields.io/badge/see-source-yellow)](https://github.com/hatena/eslint-config-hatena/blob/main/lib/classic/prettier.js)
 
 prettier を利用しているプロジェクト向けの config です。
 
@@ -179,6 +180,10 @@ export default config({
 export default config({}, [
   {
     files: ['src/**/*.js'],
+    env: {
+      es2024: true,
+      browser: true,
+    },
     rules: {
       'no-console': 0,
     },

--- a/lib/classic/javascript.js
+++ b/lib/classic/javascript.js
@@ -18,10 +18,6 @@ const config = {
     // 上書きしてもらう、という運用にする
     ecmaVersion: 2020,
   },
-  env: {
-    // `parserOptions.ecmaVersion` に揃えておく
-    es2020: true,
-  },
   rules: rules.javascript,
   overrides: [
     {

--- a/lib/classic/javascript.js
+++ b/lib/classic/javascript.js
@@ -10,13 +10,7 @@ const config = {
     // 現代では type="script" な環境で JS を書くことはまずないので、
     // デフォルトで type="module" なJSであるとして lint する
     sourceType: 'module',
-    // ES2020 の構文がパースできるように。
-    // NOTE: アプリケーションによってサポートされている ECMAScript のバージョンは違うので、
-    // 本来であればアプリケーションで利用している Node.js のバージョンやサポートブラウザの
-    // バージョンに合わせて上書きするべきするべき設定だが、いちいち上書きするのも面倒なので、
-    // ひとまず一番最新のバージョンが利用可能であるとしておき、必要に応じてアプリケーションサイドで
-    // 上書きしてもらう、という運用にする
-    ecmaVersion: 2020,
+    ecmaVersion: 'latest',
   },
   rules: rules.javascript,
   overrides: [

--- a/lib/classic/react.js
+++ b/lib/classic/react.js
@@ -20,12 +20,6 @@ const config = {
     },
   },
   rules: rules.react,
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx'],
-      rules: rules.typescriptReact,
-    },
-  ],
 };
 
 module.exports = config;

--- a/lib/classic/react.js
+++ b/lib/classic/react.js
@@ -5,7 +5,7 @@ const rules = require('../rules/index.js');
 /** @type {import('eslint').ESLint.ConfigData} */
 const config = {
   plugins: ['react', 'react-hooks'],
-  extends: ['plugin:react/recommended', 'plugin:react-hooks/recommended'],
+  extends: ['plugin:react/recommended', 'plugin:react/jsx-runtime', 'plugin:react-hooks/recommended'],
   parserOptions: {
     ecmaFeatures: {
       jsx: true,

--- a/lib/classic/react.js
+++ b/lib/classic/react.js
@@ -11,9 +11,6 @@ const config = {
       jsx: true,
     },
   },
-  env: {
-    browser: true,
-  },
   settings: {
     react: {
       version: 'detect',

--- a/lib/classic/typescript.js
+++ b/lib/classic/typescript.js
@@ -12,11 +12,9 @@ const config = {
       extends: ['plugin:@typescript-eslint/recommended-type-checked', 'plugin:import/typescript'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
-        // tsconfig.json の場所はプロジェクトによって異なるため、本来はプロジェクトに合わせて
-        // 上書きするべきするべき設定だが、いちいち上書きするのも面倒なので、ひとまず
-        // プロジェクトルートにある tsconfig.json を `parserOptions.project` にセットしてある。
-        // プロジェクトに応じて適時上書きしてもらうことを想定している。
-        project: './tsconfig.json',
+        // lint 対象のファイルに最も近い tsconfig.json を利用する。tsserver の挙動と同じなのでトラブルも少ないはず。
+        // ref: https://typescript-eslint.io/architecture/parser#project
+        project: true,
       },
       rules: rules.typescript,
     },

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -13,7 +13,7 @@ const rules = require('../rules/index.js');
  * @typedef ConfigOptions
  * @property {boolean | string | string[] | undefined} [tsProject]
  * TypeScript の設定ファイル (languageOptions.parserOptions.project)
- * デフォルト: ./tsconfig.json
+ * デフォルト: true (lint 対象のファイルに最も近い tsconfig.json を利用する)
  * @property {boolean | undefined} [react]
  * React を使用するか. true の場合, React に関連する設定を有効にする
  * デフォルト: false
@@ -29,7 +29,7 @@ const rules = require('../rules/index.js');
  * @returns {import('eslint').Linter.FlatConfig[]} 設定の配列
  */
 function config(options, configs) {
-  const tsProject = options?.tsProject ?? './tsconfig.json';
+  const tsProject = options?.tsProject ?? true;
   const react = options?.react ?? false;
   const prettier = options?.prettier ?? true;
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -46,13 +46,7 @@ function config(options, configs) {
     {
       files: ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'],
       languageOptions: {
-        // ES2020 の構文がパースできるように。
-        // NOTE: アプリケーションによってサポートされている ECMAScript のバージョンは違うので、
-        // 本来であればアプリケーションで利用している Node.js のバージョンやサポートブラウザの
-        // バージョンに合わせて上書きするべきするべき設定だが、いちいち上書きするのも面倒なので、
-        // ひとまず一番最新のバージョンが利用可能であるとしておき、必要に応じてアプリケーションサイドで
-        // 上書きしてもらう、という運用にする
-        ecmaVersion: 2020,
+        ecmaVersion: 'latest',
         parserOptions: react ? { ecmaFeatures: { jsx: true } } : {},
       },
       settings: {

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -98,6 +98,7 @@ function config(options, configs) {
       ...(react
         ? [
             { rules: reactPlugin.configs.recommended.rules },
+            { rules: reactPlugin.configs['jsx-runtime'].rules },
             { rules: reactHooksPlugin.configs.recommended.rules },
             { rules: rules.react },
           ]

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -5,7 +5,6 @@ const prettierConfig = require('eslint-config-prettier');
 const importPlugin = require('eslint-plugin-import');
 const reactPlugin = require('eslint-plugin-react');
 const reactHooksPlugin = require('eslint-plugin-react-hooks');
-const globals = require('globals');
 const tsEslint = require('typescript-eslint');
 const rules = require('../rules/index.js');
 
@@ -55,11 +54,6 @@ function config(options, configs) {
         // 上書きしてもらう、という運用にする
         ecmaVersion: 2020,
         parserOptions: react ? { ecmaFeatures: { jsx: true } } : {},
-        globals: {
-          // `ecmaVersion` に揃えておく
-          ...globals.es2020,
-          ...(react ? globals.browser : {}),
-        },
       },
       settings: {
         react: { version: 'detect' },

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -110,7 +110,6 @@ function config(options, configs) {
       ),
       { rules: importPlugin.configs.typescript.rules },
       { rules: rules.typescript },
-      ...(react ? [{ rules: rules.typescriptReact }] : []),
     ]),
     // # カスタム設定
     ...(configs ?? []),

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const javascript = require('./javascript.js');
-const { javascript: react, typescript: typescriptReact } = require('./react.js');
+const react = require('./react.js');
 const typescript = require('./typescript.js');
 
 const rules = {
   javascript,
   react,
   typescript,
-  typescriptReact,
 };
 
 module.exports = rules;

--- a/lib/rules/react.js
+++ b/lib/rules/react.js
@@ -1,20 +1,12 @@
 'use strict';
 
 /** @type {import('eslint').Linter.RulesRecord} */
-const javascript = {
+const rules = {
   // # react
   // コーディングスタイル統一のため、`<Component />` の形式で記述できる場合はそのように記述する
   'react/self-closing-comp': 2,
-};
-
-/** @type {import('eslint').Linter.RulesRecord} */
-const typescript = {
-  // # react
-  // TypeScript では propTypes は使わず TypeScript の型注釈を使えば良いので off にする
+  // props の型検査には TypeScript を使う
   'react/prop-types': 0,
 };
 
-module.exports = {
-  javascript,
-  typescript,
-};
+module.exports = rules;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -18,7 +18,11 @@ declare module 'eslint-plugin-react' {
   import type { ESLint } from 'eslint';
   const plugin: ESLint.Plugin & {
     configs: {
-      recommended: {
+      'recommended': {
+        rules: Linter.RulesRecord;
+      };
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'jsx-runtime': {
         rules: Linter.RulesRecord;
       };
     };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "globals": "^14.0.0",
     "typescript-eslint": "^7.2.0"
   },
   "peerDependencies": {
@@ -83,6 +82,7 @@
     "@types/node": "^20.11.28",
     "@types/react": "^18.2.66",
     "eslint": "^8.57.0",
+    "globals": "^14.0.0",
     "npm-run-all2": "^6.1.2",
     "prettier": "^3.2.5",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ dependencies:
   eslint-plugin-react-hooks:
     specifier: ^4.6.0
     version: 4.6.0(eslint@8.57.0)
-  globals:
-    specifier: ^14.0.0
-    version: 14.0.0
   typescript-eslint:
     specifier: ^7.2.0
     version: 7.2.0(eslint@8.57.0)(typescript@5.4.2)
@@ -58,6 +55,9 @@ devDependencies:
   eslint:
     specifier: ^8.57.0
     version: 8.57.0
+  globals:
+    specifier: ^14.0.0
+    version: 14.0.0
   npm-run-all2:
     specifier: ^6.1.2
     version: 6.1.2
@@ -1096,6 +1096,7 @@ packages:
   /globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
+    dev: true
 
   /globalthis@1.0.3:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}


### PR DESCRIPTION
https://github.com/hatena/eslint-config-hatena/pull/79 での変更を, v2 に合わせる形で取り込みました.
Flat Config 版にも同様の変更を入れています.

反対に, 旧来の .eslintrc 形式は ESLint v9 で deprecated になることから, .eslintrc のみに影響があるような変更はあえて取り込んでいません. 具体的には以下の 2 つです

- https://github.com/hatena/eslint-config-hatena/pull/79/commits/7778b2484f5871f0267143d2058b3f2ad302910a
  - もはや積極的にリファクタリングしたいことはないだろうと考えています
- https://github.com/hatena/eslint-config-hatena/pull/79/commits/65dbefdec8c224e7ebdf165352ee5e5f45a5240b
  - 今互換性を崩して .eslintrc のまま変更を強いるよりは, Flat Config に移行してもらった方が良いだろうと思っています
