### PR TITLE
eqeqeq を有効化

### DIFF
--- a/lib/rules/javascript.js
+++ b/lib/rules/javascript.js
@@ -3,6 +3,7 @@
 /** @type {import('eslint').Linter.RulesRecord} */
 const rules = {
   // # eslint
+  // == / != の暗黙の型変換の挙動はしばしば意図せぬ問題を引き起こすので, 常に === / !== を使うべき
   'eqeqeq': [2, 'always'],
   // コーディングスタイル統一のため、`const fn = function() { ... }` 形式の関数定義を禁止する。
   // 代わりに `function fn() { ... }` か `const fn = () => { ... }` 形式の関数定義を推奨する。
@@ -19,6 +20,7 @@ const rules = {
       caughtErrors: 'all',
     },
   ],
+  // 常に let / const を使うべき
   'no-var': 2,
   // 可読性のため、`let` でなくて良い場面では `const` を使うよう強制する
   'prefer-const': 2,

--- a/lib/rules/javascript.js
+++ b/lib/rules/javascript.js
@@ -3,7 +3,7 @@
 /** @type {import('eslint').Linter.RulesRecord} */
 const rules = {
   // # eslint
-  'no-var': 2,
+  'eqeqeq': [2, 'always'],
   // コーディングスタイル統一のため、`const fn = function() { ... }` 形式の関数定義を禁止する。
   // 代わりに `function fn() { ... }` か `const fn = () => { ... }` 形式の関数定義を推奨する。
   'func-style': [2, 'declaration', { allowArrowFunctions: true }],
@@ -19,6 +19,7 @@ const rules = {
       caughtErrors: 'all',
     },
   ],
+  'no-var': 2,
   // 可読性のため、`let` でなくて良い場面では `const` を使うよう強制する
   'prefer-const': 2,
   // ASI による複雑怪奇な挙動に付き合わなくて済むよう、セミコロンを必須とする


### PR DESCRIPTION
closes #53

[`eqeqeq`](https://eslint.org/docs/latest/rules/eqeqeq) を有効化します.
`== null` を例外的に許容する設定も可能ですが, eslint-config-hatena を利用しているリポジトリを調査したところ多くは見られなかったので, 一律で禁止としてしまってもよいでしょう