### PR TITLE
naming-convention ルールの調整

### DIFF
--- a/lib/rules/typescript.js
+++ b/lib/rules/typescript.js
@@ -58,9 +58,15 @@ const rules = {
     {
       selector: 'property',
       // オブジェクトのプロパティには様々な命名規則の識別子が書かれるので、緩めにしておく
-      format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+      format: ['camelCase', 'PascalCase', 'snake_case', 'UPPER_CASE'],
       leadingUnderscore: 'allow',
       trailingUnderscore: 'forbid',
+    },
+    {
+      selector: 'property',
+      modifiers: ['requiresQuotes'],
+      // クオートが必要な場合は意図してそうなっていると思われるので, フォーマットはなんでもよいことにする
+      format: null,
     },
     {
       selector: 'typeLike',

--- a/lib/rules/typescript.js
+++ b/lib/rules/typescript.js
@@ -27,12 +27,18 @@ const rules = {
   '@typescript-eslint/naming-convention': [
     1,
     {
-      selector: ['variable', 'default'],
+      selector: 'variableLike',
+      format: ['camelCase'],
+      // 末尾のアンダースコアは基本的に使われないのでデフォルトで禁止しておく。
+      // 必要に応じて allow に上書きすることを想定している。
+      leadingUnderscore: 'allow',
+      trailingUnderscore: 'forbid',
+    },
+    {
+      selector: 'variable',
       // `const CounterComponent = () => { ... }` や `const CONSTANT = 1;` のような変数が記述できるよう、
       // PascalCase や UPPER_CASE も許可する
       format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
-      // 末尾のアンダースコアは基本的に使われないのでデフォルトで禁止しておく。
-      // 必要に応じて allow に上書きすることを想定している。
       leadingUnderscore: 'allow',
       trailingUnderscore: 'forbid',
     },
@@ -44,20 +50,8 @@ const rules = {
       trailingUnderscore: 'forbid',
     },
     {
-      selector: 'parameter',
-      format: ['camelCase'],
-      leadingUnderscore: 'allow',
-      trailingUnderscore: 'forbid',
-    },
-    {
       selector: 'memberLike',
       format: ['camelCase'],
-      leadingUnderscore: 'allow',
-      trailingUnderscore: 'forbid',
-    },
-    {
-      selector: 'typeLike',
-      format: ['PascalCase'],
       leadingUnderscore: 'allow',
       trailingUnderscore: 'forbid',
     },
@@ -69,8 +63,8 @@ const rules = {
       trailingUnderscore: 'forbid',
     },
     {
-      selector: 'method',
-      format: ['camelCase'],
+      selector: 'typeLike',
+      format: ['PascalCase'],
       leadingUnderscore: 'allow',
       trailingUnderscore: 'forbid',
     },


### PR DESCRIPTION
外部 API のリクエスト / レスポンスや HTTP ヘッダなど, snake_case や kebab-case のプロパティを扱う機会は多いため, デフォルトではこれらを許容する設定にします