### PR TITLE
fix: fix ordering in the exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,12 +17,12 @@
     "./+typescript": "./lib/classic/typescript.js",
     "./flat": {
       "import": {
-        "default": "./lib/index.mjs",
-        "types": "./lib/index.d.ts"
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.mjs"
       },
       "require": {
-        "default": "./lib/index.js",
-        "types": "./lib/index.d.ts"
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
       }
     }
   },


### PR DESCRIPTION
The key order in the `exports` field is important, and `default` should be the last one.
ref. https://nodejs.org/api/packages.html#conditional-exports