### PR TITLE
React / Next.js 向けの設定を個別に利用可能にする

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -37,7 +37,7 @@ const rules = require('../rules/index.js');
  * ESLint の設定を作る
  * @param {ConfigOptions} [options] オプション
  * @param {readonly import('typescript-eslint').ConfigWithExtends[]} [configs] カスタム設定の配列
- * @returns {import('typescript-eslint').Config} 設定の配列
+ * @returns {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} 設定の配列
  */
 function config(options, configs) {
   const tsProject = options?.tsProject ?? true;

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -85,7 +85,6 @@ function config(options, configs) {
       files: ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'],
       languageOptions: {
         ecmaVersion: 'latest',
-        parserOptions: react ? { ecmaFeatures: { jsx: true } } : {},
       },
     },
     {
@@ -113,6 +112,15 @@ function config(options, configs) {
         parserOptions: {
           ...(tsProjectService ? { projectService: tsProjectService } : tsProject ? { project: tsProject } : {}),
           tsconfigRootDir,
+        },
+      },
+    },
+    {
+      name: '@hatena/eslint-config-hatena/language-settings/jsx',
+      files: ['**/*.jsx', '**/*.tsx'],
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
         },
       },
     },

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,14 +1,12 @@
 'use strict';
 
 const jsPlugin = require('@eslint/js');
-const nextPlugin = require('@next/eslint-plugin-next');
 const prettierConfig = require('eslint-config-prettier');
 const importPlugin = require('eslint-plugin-import');
-const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
-const reactPlugin = require('eslint-plugin-react');
-const reactHooksPlugin = require('eslint-plugin-react-hooks');
 const tsEslint = require('typescript-eslint');
 const rules = require('../rules/index.js');
+const nextConfig = require('./next.js');
+const reactConfig = require('./react.js');
 
 /**
  * @typedef ConfigOptions
@@ -52,17 +50,10 @@ function config(options, configs) {
     {
       name: '@hatena/eslint-config-hatena/global-settings',
       plugins: {
-        '@typescript-eslint': tsEslint.plugin,
         'import': importPlugin,
-        'react': reactPlugin,
-        'react-hooks': reactHooksPlugin,
-        '@next/next': nextPlugin,
-        'jsx-a11y': jsxA11yPlugin,
+        '@typescript-eslint': tsEslint.plugin,
       },
       settings: {
-        'react': {
-          version: 'detect',
-        },
         // 参考: https://github.com/import-js/eslint-plugin-import/blob/main/config/typescript.js
         'import/extensions': ['.js', '.jsx', '.cjs', '.mjs', '.ts', '.tsx', '.cts', '.mts'],
         'import/external-module-folders': ['node_modules', 'node_modules/@types'],
@@ -131,37 +122,6 @@ function config(options, configs) {
       extends: [{ rules: jsPlugin.configs.recommended.rules }, { rules: importPlugin.configs.recommended.rules }],
       rules: rules.javascript,
     },
-    ...(react || next
-      ? [
-          {
-            name: '@hatena/eslint-config-hatena/rules/react',
-            files: ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'],
-            extends: [
-              { rules: reactPlugin.configs.recommended.rules },
-              { rules: reactPlugin.configs['jsx-runtime'].rules },
-              { rules: reactHooksPlugin.configs.recommended.rules },
-            ],
-            rules: rules.react,
-          },
-        ]
-      : []),
-    ...(next
-      ? [
-          {
-            name: '@hatena/eslint-config-hatena/rules/next',
-            files: ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'],
-            extends: [
-              {
-                rules: {
-                  ...nextPlugin.configs.recommended.rules,
-                  ...(next === 'strict' ? nextPlugin.configs['core-web-vitals'].rules : {}),
-                },
-              },
-            ],
-            rules: rules.next,
-          },
-        ]
-      : []),
     {
       name: '@hatena/eslint-config-hatena/rules/ts',
       files: ['**/*.{ts,tsx,cts,mts}'],
@@ -172,6 +132,8 @@ function config(options, configs) {
       ],
       rules: rules.typescript,
     },
+    // # ライブラリ・フレームワーク向けの設定
+    ...(next ? nextConfig({ strict: next === 'strict' }) : react ? reactConfig() : []),
     // # カスタム設定
     ...(configs ?? []),
     // # フォーマットに関するルールを無効化

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -148,4 +148,7 @@ function config(options, configs) {
   );
 }
 
+config.react = reactConfig;
+config.next = nextConfig;
+
 module.exports = config;

--- a/lib/config/next.js
+++ b/lib/config/next.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const nextPlugin = require('@next/eslint-plugin-next');
+const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
+const tsEslint = require('typescript-eslint');
+const rules = require('../rules/index.js');
+const reactConfig = require('./react.js');
+
+/**
+ * @typedef ConfigOptions
+ * @property {boolean | undefined} [strict]
+ * true の場合, Core Web Vitals に関するルールを追加で有効にする.
+ * デフォルト: false
+ */
+
+/**
+ * Next.js を使用するプロジェクト向けの設定. React 向けの設定も内包している.
+ * @param {ConfigOptions} [options] オプション
+ * @returns {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} 設定の配列
+ */
+function config(options) {
+  const strict = options?.strict ?? false;
+
+  const files = ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'];
+
+  return tsEslint.config(
+    {
+      name: '@hatena/eslint-config-hatena/next/react',
+      files,
+      extends: reactConfig(),
+    },
+    {
+      name: '@hatena/eslint-config-hatena/next/plugins',
+      files,
+      plugins: {
+        '@next/next': nextPlugin,
+        'jsx-a11y': jsxA11yPlugin,
+      },
+    },
+    {
+      name: '@hatena/eslint-config-hatena/next/rules',
+      files,
+      extends: [
+        {
+          rules: {
+            ...nextPlugin.configs.recommended.rules,
+            ...(strict ? nextPlugin.configs['core-web-vitals'].rules : {}),
+          },
+        },
+      ],
+      rules: rules.next,
+    },
+  );
+}
+
+module.exports = config;

--- a/lib/config/next.js
+++ b/lib/config/next.js
@@ -21,17 +21,18 @@ const reactConfig = require('./react.js');
 function config(options) {
   const strict = options?.strict ?? false;
 
-  const files = ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'];
+  // NOTE: files は extends によって一括で上書きされることもある
+  const defaultFiles = ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'];
 
   return tsEslint.config(
     {
       name: '@hatena/eslint-config-hatena/next/react',
-      files,
+      files: defaultFiles,
       extends: reactConfig(),
     },
     {
       name: '@hatena/eslint-config-hatena/next/plugins',
-      files,
+      files: defaultFiles,
       plugins: {
         '@next/next': nextPlugin,
         'jsx-a11y': jsxA11yPlugin,
@@ -39,7 +40,7 @@ function config(options) {
     },
     {
       name: '@hatena/eslint-config-hatena/next/rules',
-      files,
+      files: defaultFiles,
       extends: [
         {
           rules: {

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -10,12 +10,13 @@ const rules = require('../rules/index.js');
  * @returns {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} 設定の配列
  */
 function config() {
-  const files = ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'];
+  // NOTE: files は extends によって一括で上書きされることもある
+  const defaultFiles = ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'];
 
   return tsEslint.config(
     {
       name: '@hatena/eslint-config-hatena/react/plugins',
-      files,
+      files: defaultFiles,
       plugins: {
         'react': reactPlugin,
         'react-hooks': reactHooksPlugin,
@@ -28,7 +29,7 @@ function config() {
     },
     {
       name: '@hatena/eslint-config-hatena/react/rules',
-      files,
+      files: defaultFiles,
       extends: [
         { rules: reactPlugin.configs.recommended.rules },
         { rules: reactPlugin.configs['jsx-runtime'].rules },

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const reactPlugin = require('eslint-plugin-react');
+const reactHooksPlugin = require('eslint-plugin-react-hooks');
+const tsEslint = require('typescript-eslint');
+const rules = require('../rules/index.js');
+
+/**
+ * React を使用するプロジェクト向けの設定
+ * @returns {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} 設定の配列
+ */
+function config() {
+  const files = ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'];
+
+  return tsEslint.config(
+    {
+      name: '@hatena/eslint-config-hatena/react/plugins',
+      files,
+      plugins: {
+        'react': reactPlugin,
+        'react-hooks': reactHooksPlugin,
+      },
+      settings: {
+        react: {
+          version: 'detect',
+        },
+      },
+    },
+    {
+      name: '@hatena/eslint-config-hatena/react/rules',
+      files,
+      extends: [
+        { rules: reactPlugin.configs.recommended.rules },
+        { rules: reactPlugin.configs['jsx-runtime'].rules },
+        { rules: reactHooksPlugin.configs.recommended.rules },
+      ],
+      rules: rules.react,
+    },
+  );
+}
+
+module.exports = config;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,6 @@
 import { ParserOptions } from '@typescript-eslint/parser';
-import { Config, ConfigWithExtends } from 'typescript-eslint';
+import { TSESLint } from '@typescript-eslint/utils';
+import { ConfigWithExtends } from 'typescript-eslint';
 
 type ConfigOptions = Readonly<
   Partial<{
@@ -37,13 +38,35 @@ type ConfigOptions = Readonly<
   }>
 >;
 
-/**
- * ESLint の設定を作る
- * @param options オプション
- * @param configs カスタム設定の配列
- * @returns 設定の配列
- */
-declare function config(options?: ConfigOptions, configs?: readonly ConfigWithExtends[]): Config[];
+type NextConfigOptions = Readonly<
+  Partial<{
+    /**
+     * true の場合, Core Web Vitals に関するルールを追加で有効にする.
+     * デフォルト: false
+     */
+    strict: boolean | undefined;
+  }>
+>;
 
-export { type ConfigOptions, config };
+declare const config: {
+  /**
+   * ESLint の設定を作る
+   * @param options オプション
+   * @param configs カスタム設定の配列
+   * @returns 設定の配列
+   */
+  (options?: ConfigOptions, configs?: readonly ConfigWithExtends[]): TSESLint.FlatConfig.ConfigArray;
+  /**
+   * React を使用するプロジェクト向けの設定
+   * @returns 設定の配列
+   */
+  react: () => TSESLint.FlatConfig.ConfigArray;
+  /**
+   * Next.js を使用するプロジェクト向けの設定. React 向けの設定も内包している.
+   * @returns 設定の配列
+   */
+  next: (options?: NextConfigOptions) => TSESLint.FlatConfig.ConfigArray;
+};
+
+export { type ConfigOptions, type NextConfigOptions, config };
 export default config;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/eslint": "^9.6.1",
     "@typescript-eslint/eslint-plugin": "^8.17.0",
     "@typescript-eslint/parser": "^8.17.0",
+    "@typescript-eslint/utils": "^8.18.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-node": "^0.3.9",
     "eslint-import-resolver-typescript": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/eslint": "^9.6.1",
     "@typescript-eslint/eslint-plugin": "^8.17.0",
     "@typescript-eslint/parser": "^8.17.0",
-    "@typescript-eslint/utils": "^8.18.1",
+    "@typescript-eslint/utils": "^8.17.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-node": "^0.3.9",
     "eslint-import-resolver-typescript": "^3.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^8.17.0
         version: 8.17.0(eslint@9.16.0)(typescript@5.6.3)
       '@typescript-eslint/utils':
-        specifier: ^8.18.1
-        version: 8.18.1(eslint@9.16.0)(typescript@5.6.3)
+        specifier: ^8.17.0
+        version: 8.17.0(eslint@9.16.0)(typescript@5.6.3)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.16.0)
@@ -227,10 +227,6 @@ packages:
     resolution: {integrity: sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/scope-manager@8.18.1':
-    resolution: {integrity: sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/type-utils@8.17.0':
     resolution: {integrity: sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -245,10 +241,6 @@ packages:
     resolution: {integrity: sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/types@8.18.1':
-    resolution: {integrity: sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@typescript-eslint/typescript-estree@8.17.0':
     resolution: {integrity: sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -257,12 +249,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  '@typescript-eslint/typescript-estree@8.18.1':
-    resolution: {integrity: sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.8.0'
 
   '@typescript-eslint/utils@8.17.0':
     resolution: {integrity: sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==}
@@ -274,19 +260,8 @@ packages:
       typescript:
         optional: true
 
-  '@typescript-eslint/utils@8.18.1':
-    resolution: {integrity: sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.8.0'
-
   '@typescript-eslint/visitor-keys@8.17.0':
     resolution: {integrity: sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/visitor-keys@8.18.1':
-    resolution: {integrity: sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   acorn-jsx@5.3.2:
@@ -1405,11 +1380,6 @@ snapshots:
       '@typescript-eslint/types': 8.17.0
       '@typescript-eslint/visitor-keys': 8.17.0
 
-  '@typescript-eslint/scope-manager@8.18.1':
-    dependencies:
-      '@typescript-eslint/types': 8.18.1
-      '@typescript-eslint/visitor-keys': 8.18.1
-
   '@typescript-eslint/type-utils@8.17.0(eslint@9.16.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.17.0(typescript@5.6.3)
@@ -1423,8 +1393,6 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.17.0': {}
-
-  '@typescript-eslint/types@8.18.1': {}
 
   '@typescript-eslint/typescript-estree@8.17.0(typescript@5.6.3)':
     dependencies:
@@ -1441,20 +1409,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.18.1(typescript@5.6.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.18.1
-      '@typescript-eslint/visitor-keys': 8.18.1
-      debug: 4.3.7
-      fast-glob: 3.3.2
-      is-glob: 4.0.3
-      minimatch: 9.0.5
-      semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.3)
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/utils@8.17.0(eslint@9.16.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.16.0)
@@ -1467,25 +1421,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.18.1(eslint@9.16.0)(typescript@5.6.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@9.16.0)
-      '@typescript-eslint/scope-manager': 8.18.1
-      '@typescript-eslint/types': 8.18.1
-      '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.6.3)
-      eslint: 9.16.0
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/visitor-keys@8.17.0':
     dependencies:
       '@typescript-eslint/types': 8.17.0
-      eslint-visitor-keys: 4.2.0
-
-  '@typescript-eslint/visitor-keys@8.18.1':
-    dependencies:
-      '@typescript-eslint/types': 8.18.1
       eslint-visitor-keys: 4.2.0
 
   acorn-jsx@5.3.2(acorn@8.14.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.17.0
         version: 8.17.0(eslint@9.16.0)(typescript@5.6.3)
+      '@typescript-eslint/utils':
+        specifier: ^8.18.1
+        version: 8.18.1(eslint@9.16.0)(typescript@5.6.3)
       eslint-config-prettier:
         specifier: ^9.1.0
         version: 9.1.0(eslint@9.16.0)
@@ -224,6 +227,10 @@ packages:
     resolution: {integrity: sha512-/ewp4XjvnxaREtqsZjF4Mfn078RD/9GmiEAtTeLQ7yFdKnqwTOgRMSvFz4et9U5RiJQ15WTGXPLj89zGusvxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/scope-manager@8.18.1':
+    resolution: {integrity: sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/type-utils@8.17.0':
     resolution: {integrity: sha512-q38llWJYPd63rRnJ6wY/ZQqIzPrBCkPdpIsaCfkR3Q4t3p6sb422zougfad4TFW9+ElIFLVDzWGiGAfbb/v2qw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -238,6 +245,10 @@ packages:
     resolution: {integrity: sha512-gY2TVzeve3z6crqh2Ic7Cr+CAv6pfb0Egee7J5UAVWCpVvDI/F71wNfolIim4FE6hT15EbpZFVUj9j5i38jYXA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript-eslint/types@8.18.1':
+    resolution: {integrity: sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@typescript-eslint/typescript-estree@8.17.0':
     resolution: {integrity: sha512-JqkOopc1nRKZpX+opvKqnM3XUlM7LpFMD0lYxTqOTKQfCWAmxw45e3qlOCsEqEB2yuacujivudOFpCnqkBDNMw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -246,6 +257,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@typescript-eslint/typescript-estree@8.18.1':
+    resolution: {integrity: sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
 
   '@typescript-eslint/utils@8.17.0':
     resolution: {integrity: sha512-bQC8BnEkxqG8HBGKwG9wXlZqg37RKSMY7v/X8VEWD8JG2JuTHuNK0VFvMPMUKQcbk6B+tf05k+4AShAEtCtJ/w==}
@@ -257,8 +274,19 @@ packages:
       typescript:
         optional: true
 
+  '@typescript-eslint/utils@8.18.1':
+    resolution: {integrity: sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
   '@typescript-eslint/visitor-keys@8.17.0':
     resolution: {integrity: sha512-1Hm7THLpO6ww5QU6H/Qp+AusUUl+z/CAm3cNZZ0jQvon9yicgO7Rwd+/WWRpMKLYV6p2UvdbR27c86rzCPpreg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/visitor-keys@8.18.1':
+    resolution: {integrity: sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   acorn-jsx@5.3.2:
@@ -1377,6 +1405,11 @@ snapshots:
       '@typescript-eslint/types': 8.17.0
       '@typescript-eslint/visitor-keys': 8.17.0
 
+  '@typescript-eslint/scope-manager@8.18.1':
+    dependencies:
+      '@typescript-eslint/types': 8.18.1
+      '@typescript-eslint/visitor-keys': 8.18.1
+
   '@typescript-eslint/type-utils@8.17.0(eslint@9.16.0)(typescript@5.6.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 8.17.0(typescript@5.6.3)
@@ -1390,6 +1423,8 @@ snapshots:
       - supports-color
 
   '@typescript-eslint/types@8.17.0': {}
+
+  '@typescript-eslint/types@8.18.1': {}
 
   '@typescript-eslint/typescript-estree@8.17.0(typescript@5.6.3)':
     dependencies:
@@ -1406,6 +1441,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.18.1(typescript@5.6.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.18.1
+      '@typescript-eslint/visitor-keys': 8.18.1
+      debug: 4.3.7
+      fast-glob: 3.3.2
+      is-glob: 4.0.3
+      minimatch: 9.0.5
+      semver: 7.6.3
+      ts-api-utils: 1.3.0(typescript@5.6.3)
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.17.0(eslint@9.16.0)(typescript@5.6.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.16.0)
@@ -1418,9 +1467,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.18.1(eslint@9.16.0)(typescript@5.6.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.4.1(eslint@9.16.0)
+      '@typescript-eslint/scope-manager': 8.18.1
+      '@typescript-eslint/types': 8.18.1
+      '@typescript-eslint/typescript-estree': 8.18.1(typescript@5.6.3)
+      eslint: 9.16.0
+      typescript: 5.6.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/visitor-keys@8.17.0':
     dependencies:
       '@typescript-eslint/types': 8.17.0
+      eslint-visitor-keys: 4.2.0
+
+  '@typescript-eslint/visitor-keys@8.18.1':
+    dependencies:
+      '@typescript-eslint/types': 8.18.1
       eslint-visitor-keys: 4.2.0
 
   acorn-jsx@5.3.2(acorn@8.14.0):


### PR DESCRIPTION
これまでは React / Next.js 向けの設定は全体で有効にする必要がありましたが, monorepo で一つの eslint.config.js を使う場合など, ディレクトリごとに細かく有効 / 無効を制御したい場合には不向きでした.

``` ts
import config from "@hatena/eslint-config-hatena/flat";

export default config({ react: true });
// または
export default config({ next: "strict" });
```

そこで新たに `config.react()`, `config.next()` を追加し, 同様の設定をディレクトリごとに行えるようにします.
(上記の方法も引き続きサポートされます.)

``` ts
import config from "@hatena/eslint-config-hatena/flat";

export default config({}, [
  // foo 以下では React 向けの設定を有効化する
  {
    files: ["foo/**/*.{ts,tsx}"],
    extends: config.react(),
  },
  // bar 以下では Next.js 向けの設定を有効化する (React 向けの設定も内包)
  {
    files: ["bar/**/*.{ts,tsx}"],
    extends: config.next({ strict: true }),
  },
]);
```