### PR TITLE
ルールの更新

### DIFF
--- a/lib/rules/javascript.js
+++ b/lib/rules/javascript.js
@@ -26,6 +26,8 @@ const rules = {
   'no-var': 2,
   // 可読性のため、`let` でなくて良い場面では `const` を使うよう強制する
   'prefer-const': 2,
+  // parseInt の第二引数を必須にする
+  'radix': 2,
   // ASI による複雑怪奇な挙動に付き合わなくて済むよう、セミコロンを必須とする
   'semi': [2, 'always'],
   // 生の *.js では `'use strict';` を必須とする

--- a/lib/rules/next.js
+++ b/lib/rules/next.js
@@ -4,6 +4,8 @@
 
 /** @type {import('eslint').Linter.RulesRecord} */
 const rules = {
+  // フレームワークの規約上 default export を使うことも多いので無効化
+  'import/no-default-export': 'off',
   'import/no-anonymous-default-export': 'warn',
   'react/jsx-no-target-blank': 'off',
   'react/no-unknown-property': 'off',


### PR DESCRIPTION
- Next.js では規約上 default export を頻繁に使うので, `import/no-default-export` はデフォルトでは無効化しておく
- `radix` を有効化
  - https://eslint.org/docs/latest/rules/radix
