### PR TITLE
feat: use defineConfig from @eslint/config-helpers

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -52,7 +52,7 @@ function config(options, ...configs) {
       name: '@hatena/eslint-config-hatena/global-settings',
       plugins: {
         'import': importPlugin,
-        '@typescript-eslint': /** @type {any} */ (tsEslint.plugin),
+        '@typescript-eslint': /** @type {import('eslint').ESLint.Plugin} */ (tsEslint.plugin),
       },
       settings: {
         // 参考: https://github.com/import-js/eslint-plugin-import/blob/main/config/typescript.js
@@ -100,7 +100,7 @@ function config(options, ...configs) {
       files: ['**/*.{ts,tsx,cts,mts}'],
       languageOptions: {
         sourceType: 'module',
-        parser: /** @type {any} */ (tsEslint.parser),
+        parser: /** @type {import('eslint').Linter.Parser} */ (tsEslint.parser),
         parserOptions: {
           ...(tsProjectService ? { projectService: tsProjectService } : tsProject ? { project: tsProject } : {}),
           tsconfigRootDir,

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -128,24 +128,24 @@ function config(options, ...configs) {
       files: ['**/*.{ts,tsx,cts,mts}'],
       extends: [
         // recommendedTypeChecked には languageOptions なども含まれるが, 上で設定しているものと重複するのでここでは rules のみに絞る
-        ...tsEslint.configs.recommendedTypeChecked.flatMap((config) => (config.rules ? [{ rules: config.rules }] : [])),
+        tsEslint.configs.recommendedTypeChecked.flatMap((config) => (config.rules ? [{ rules: config.rules }] : [])),
         { rules: importPlugin.configs.typescript.rules },
       ],
       rules: rules.typescript,
     },
     // # ライブラリ・フレームワーク向けの設定
-    ...(next ? nextConfig({ strict: next === 'strict' }) : react ? reactConfig() : []),
+    next ? nextConfig({ strict: next === 'strict' }) : react ? reactConfig() : [],
     // # カスタム設定
-    ...(configs ?? []),
+    configs,
     // # フォーマットに関するルールを無効化
-    ...(prettier
+    prettier
       ? [
           {
             name: '@hatena/eslint-config-hatena/rules/prettier',
             rules: prettierConfig.rules,
           },
         ]
-      : []),
+      : [],
   );
 }
 

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { defineConfig } = require('@eslint/config-helpers');
 const jsPlugin = require('@eslint/js');
 const prettierConfig = require('eslint-config-prettier');
 const importPlugin = require('eslint-plugin-import');
@@ -34,10 +35,10 @@ const reactConfig = require('./react.js');
 /**
  * ESLint の設定を作る
  * @param {ConfigOptions} [options] オプション
- * @param {readonly import('typescript-eslint').ConfigWithExtends[]} [configs] カスタム設定の配列
- * @returns {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} 設定の配列
+ * @param {import('@eslint/config-helpers').ConfigWithExtendsArray} configs カスタム設定の配列
+ * @returns {import('eslint').Linter.Config[]} 設定の配列
  */
-function config(options, configs) {
+function config(options, ...configs) {
   const tsProject = options?.tsProject ?? true;
   const tsProjectService = options?.tsProjectService ?? false;
   const tsconfigRootDir = options?.tsconfigRootDir ?? undefined;
@@ -45,13 +46,13 @@ function config(options, configs) {
   const next = options?.next ?? false;
   const prettier = options?.prettier ?? true;
 
-  return tsEslint.config(
+  return defineConfig(
     // # Linter やプラグインの設定
     {
       name: '@hatena/eslint-config-hatena/global-settings',
       plugins: {
         'import': importPlugin,
-        '@typescript-eslint': tsEslint.plugin,
+        '@typescript-eslint': /** @type {any} */ (tsEslint.plugin),
       },
       settings: {
         // 参考: https://github.com/import-js/eslint-plugin-import/blob/main/config/typescript.js
@@ -99,7 +100,7 @@ function config(options, configs) {
       files: ['**/*.{ts,tsx,cts,mts}'],
       languageOptions: {
         sourceType: 'module',
-        parser: tsEslint.parser,
+        parser: /** @type {any} */ (tsEslint.parser),
         parserOptions: {
           ...(tsProjectService ? { projectService: tsProjectService } : tsProject ? { project: tsProject } : {}),
           tsconfigRootDir,

--- a/lib/config/next.js
+++ b/lib/config/next.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const { defineConfig } = require('@eslint/config-helpers');
 const nextPlugin = require('@next/eslint-plugin-next');
 const jsxA11yPlugin = require('eslint-plugin-jsx-a11y');
-const tsEslint = require('typescript-eslint');
 const rules = require('../rules/index.js');
 const reactConfig = require('./react.js');
 
@@ -16,7 +16,7 @@ const reactConfig = require('./react.js');
 /**
  * Next.js を使用するプロジェクト向けの設定. React 向けの設定も内包している.
  * @param {ConfigOptions} [options] オプション
- * @returns {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} 設定の配列
+ * @returns {import('eslint').Linter.Config[]} 設定の配列
  */
 function config(options) {
   const strict = options?.strict ?? false;
@@ -24,7 +24,7 @@ function config(options) {
   // NOTE: files は extends によって一括で上書きされることもある
   const defaultFiles = ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'];
 
-  return tsEslint.config(
+  return defineConfig(
     {
       name: '@hatena/eslint-config-hatena/next/react',
       files: defaultFiles,

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -1,19 +1,19 @@
 'use strict';
 
+const { defineConfig } = require('@eslint/config-helpers');
 const reactPlugin = require('eslint-plugin-react');
 const reactHooksPlugin = require('eslint-plugin-react-hooks');
-const tsEslint = require('typescript-eslint');
 const rules = require('../rules/index.js');
 
 /**
  * React を使用するプロジェクト向けの設定
- * @returns {import('@typescript-eslint/utils').TSESLint.FlatConfig.ConfigArray} 設定の配列
+ * @returns {import('eslint').Linter.Config[]} 設定の配列
  */
 function config() {
   // NOTE: files は extends によって一括で上書きされることもある
   const defaultFiles = ['**/*.{js,jsx,cjs,mjs}', '**/*.{ts,tsx,cts,mts}'];
 
-  return tsEslint.config(
+  return defineConfig(
     {
       name: '@hatena/eslint-config-hatena/react/plugins',
       files: defaultFiles,

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -55,3 +55,9 @@ declare module '@next/eslint-plugin-next' {
   };
   export = plugin;
 }
+
+declare module 'eslint-plugin-jsx-a11y' {
+  import type { ESLint } from 'eslint';
+  const plugin: ESLint.Plugin;
+  export = plugin;
+}

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   "devDependencies": {
     "@hatena/prettier-config-hatena": "github:hatena/prettier-config-hatena#v1.0.0",
     "@types/eslint-config-prettier": "^6.11.3",
-    "@types/eslint-plugin-jsx-a11y": "^6.10.0",
     "@types/node": "^22.13.10",
     "@types/react": "^19.0.10",
     "eslint": "^9.22.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "prepublishOnly": "run-s format:check lint:check typecheck configtest"
   },
   "dependencies": {
+    "@eslint/config-helpers": "^0.1.0",
     "@eslint/js": "^9.22.0",
     "@next/eslint-plugin-next": "^15.2.2",
     "@typescript-eslint/eslint-plugin": "^8.26.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@eslint/config-helpers':
+        specifier: ^0.1.0
+        version: 0.1.0
       '@eslint/js':
         specifier: ^9.22.0
         version: 9.22.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       '@types/eslint-config-prettier':
         specifier: ^6.11.3
         version: 6.11.3
-      '@types/eslint-plugin-jsx-a11y':
-        specifier: ^6.10.0
-        version: 6.10.0
       '@types/node':
         specifier: ^22.13.10
         version: 22.13.10
@@ -175,12 +172,6 @@ packages:
 
   '@types/eslint-config-prettier@6.11.3':
     resolution: {integrity: sha512-3wXCiM8croUnhg9LdtZUJQwNcQYGWxxdOWDjPe1ykCqJFPVpzAKfs/2dgSoCtAvdPeaponcWPI7mPcGGp9dkKQ==}
-
-  '@types/eslint-plugin-jsx-a11y@6.10.0':
-    resolution: {integrity: sha512-TGKmk2gO6DrvTVADNOGQMqn3SzqcFcJILFnXNllQA34us9uClS3/AsL/cERPz6jS9ePI3bx+1q8/d2GZsxPVYw==}
-
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1361,15 +1352,6 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@types/eslint-config-prettier@6.11.3': {}
-
-  '@types/eslint-plugin-jsx-a11y@6.10.0':
-    dependencies:
-      '@types/eslint': 9.6.1
-
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.6
-      '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.6': {}
 


### PR DESCRIPTION
- Replace `tseslint.config()` with `defineConfig()`, which is expected to become the standard way to define flat configs.
  - [Evolving flat config with extends - ESLint - Pluggable JavaScript Linter](https://eslint.org/blog/2025/03/flat-config-extends-define-config-global-ignores/)
- Also use types provided by eslint itself.

